### PR TITLE
Rebase CoreOS docker release branch on v1.8.3

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1482,12 +1482,16 @@ func (devices *DeviceSet) deactivatePool() error {
 	if err != nil {
 		return err
 	}
-	if d, err := devicemapper.GetDeps(devname); err == nil {
-		// Access to more Debug output
-		logrus.Debugf("[devmapper] devicemapper.GetDeps() %s: %#v", devname, d)
+
+	if devinfo.Exists == 0 {
+		return nil
 	}
-	if devinfo.Exists != 0 {
-		return devicemapper.RemoveDevice(devname)
+	if err := devicemapper.RemoveDevice(devname); err != nil {
+		return err
+	}
+
+	if d, err := devicemapper.GetDeps(devname); err == nil {
+		logrus.Warnf("[devmapper] device %s still has %d active dependents", devname, d.Count)
 	}
 
 	return nil

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -38,7 +38,10 @@ static void	log_with_errno_init()
 */
 import "C"
 
-import "unsafe"
+import (
+	"reflect"
+	"unsafe"
+)
 
 type (
 	CDmTask C.struct_dm_task
@@ -184,12 +187,21 @@ func dmTaskGetDepsFct(task *CDmTask) *Deps {
 	if Cdeps == nil {
 		return nil
 	}
+
+	// golang issue: https://github.com/golang/go/issues/11925
+	hdr := reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(uintptr(unsafe.Pointer(Cdeps)) + unsafe.Sizeof(*Cdeps))),
+		Len:  int(Cdeps.count),
+		Cap:  int(Cdeps.count),
+	}
+	devices := *(*[]C.uint64_t)(unsafe.Pointer(&hdr))
+
 	deps := &Deps{
 		Count:  uint32(Cdeps.count),
 		Filler: uint32(Cdeps.filler),
 	}
-	for _, device := range Cdeps.device {
-		deps.Device = append(deps.Device, (uint64)(device))
+	for _, device := range devices {
+		deps.Device = append(deps.Device, uint64(device))
 	}
 	return deps
 }


### PR DESCRIPTION
devicemapper: fix zero-sized field access

Fixes: #15279

Due to
https://github.com/golang/go/commit/7904946eeb35faece61bbf6f5b3cc8be2f519c17
the devices field is dropped.

This solution works on go1.4 and go1.5

Signed-off-by: Vincent Batts vbatts@redhat.com
