### PR TITLE
Revert "selinux/overlay incompatible err"

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -262,9 +262,9 @@ func checkSystem() error {
 func configureKernelSecuritySupport(config *Config, driverName string) error {
 	if config.EnableSelinuxSupport {
 		if selinuxEnabled() {
-			// As Docker on either btrfs or overlayFS and SELinux are incompatible at present, error on both being enabled
-			if driverName == "btrfs" || driverName == "overlay" {
-				return fmt.Errorf("SELinux is not supported with the %s graph driver", driverName)
+			// As Docker on btrfs and SELinux are incompatible at present, error on both being enabled
+			if driverName == "btrfs" {
+				return fmt.Errorf("SELinux is not supported with the BTRFS graph driver")
 			}
 			logrus.Debug("SELinux enabled successfully")
 		} else {


### PR DESCRIPTION
This reverts commit 04329e0b3e47e411ebf0a4ba8947be6e87014737.
