### PR TITLE
Label overlay directories appropriately

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -361,6 +361,16 @@ func (d *Driver) Get(id string, mountLabel string) (string, error) {
 	workDir := path.Join(dir, "work")
 	mergedDir := path.Join(dir, "merged")
 
+	if err = label.Relabel(upperDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling upper directory: %v", err)
+	}
+	if err = label.Relabel(workDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling work directory: %v", err)
+	}
+	if err = label.Relabel(mergedDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling merged directory: %v", err)
+	}
+
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, upperDir, workDir)
 	if err := syscall.Mount("overlay", mergedDir, "overlay", 0, label.FormatMountLabel(opts, mountLabel)); err != nil {
 		return "", fmt.Errorf("error creating overlay mount to %s: %v", mergedDir, err)


### PR DESCRIPTION
New files and copy_up() operations on overlayfs will check permissions
against the security context on the upper directories in the overlayfs
mounts. Label them all appropriately.
