### PR TITLE
Return errors if relabelling fails

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -361,9 +361,15 @@ func (d *Driver) Get(id string, mountLabel string) (string, error) {
 	workDir := path.Join(dir, "work")
 	mergedDir := path.Join(dir, "merged")
 
-	label.Relabel(upperDir, mountLabel, false)
-	label.Relabel(workDir, mountLabel, false)
-	label.Relabel(mergedDir, mountLabel, false)
+	if err = label.Relabel(upperDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling upper directory: %v", err)
+	}
+	if err = label.Relabel(workDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling work directory: %v", err)
+	}
+	if err = label.Relabel(mergedDir, mountLabel, false); err != nil {
+		return "", fmt.Errorf("Error relabeling merged directory: %v", err)
+	}
 
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, upperDir, workDir)
 	if err := syscall.Mount("overlay", mergedDir, "overlay", 0, label.FormatMountLabel(opts, mountLabel)); err != nil {


### PR DESCRIPTION
If we somehow fail to relabel the fs, we should return an error rather than
blindly continuing.
