### PR TITLE
Revert "Use fs cgroups by default"

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -74,6 +74,9 @@ func NewDriver(root string, options []string) (*Driver, error) {
 	// this makes sure there are no breaking changes to people
 	// who upgrade from versions without native.cgroupdriver opt
 	cgm := libcontainer.Cgroupfs
+	if systemd.UseSystemd() {
+		cgm = libcontainer.SystemdCgroups
+	}
 
 	// parse the options
 	for _, option := range options {

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -462,11 +462,11 @@ single `native.cgroupdriver` option is available.
 
 The `native.cgroupdriver` option specifies the management of the container's
 cgroups. You can specify `cgroupfs` or `systemd`. If you specify `systemd` and
-it is not available, the system uses `cgroupfs`. If you omit the
-`native.cgroupdriver` option,` cgroupfs` is used.
-This example sets the `cgroupdriver` to `systemd`:
+it is not available, the system uses `cgroupfs`. By default, if no option is
+specified, the execdriver first tries `systemd` and falls back to `cgroupfs`.
+This example sets the execdriver to `cgroupfs`:
 
-    $ sudo docker daemon --exec-opt native.cgroupdriver=systemd
+    $ sudo docker daemon --exec-opt native.cgroupdriver=cgroupfs
 
 Setting this option applies to all containers the daemon launches.
 


### PR DESCRIPTION
This reverts commit 419fd7449fe1a984f582731fcd4d9455000846b0.

Fixes https://github.com/coreos/bugs/issues/1132
