### PR TITLE
overlayfs: Don't attempt to relabel the merged directory

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -370,9 +370,6 @@ func (d *Driver) Get(id string, mountLabel string) (string, error) {
 	if err = label.Relabel(workDir, mountLabel, false); err != nil {
 		return "", fmt.Errorf("Error relabeling work directory: %v", err)
 	}
-	if err = label.Relabel(mergedDir, mountLabel, false); err != nil {
-		return "", fmt.Errorf("Error relabeling merged directory: %v", err)
-	}
 
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, upperDir, workDir)
 	if err := syscall.Mount("overlay", mergedDir, "overlay", 0, label.FormatMountLabel(opts, mountLabel)); err != nil {


### PR DESCRIPTION
The merged directory will inherit its selinux context from the overlayfs mount, and
it can't be relabelled if it's _on_ an overlayfs mount (for instance, if docker is
being run inside docker).
