### PR TITLE
Backport fix for docker stats in 1.10.3

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1487,10 +1487,29 @@ func (daemon *Daemon) GetContainerStats(container *container.Container) (*execdr
 	return stats, nil
 }
 
+// Resolve Network SandboxID in case the container reuse another container's network stack
+func (daemon *Daemon) getNetworkSandboxID(c *container.Container) (string, error) {
+	curr := c
+	for curr.HostConfig.NetworkMode.IsContainer() {
+		containerID := curr.HostConfig.NetworkMode.ConnectedContainer()
+		connected, err := daemon.GetContainer(containerID)
+		if err != nil {
+			return "", fmt.Errorf("Could not get container for %s", containerID)
+		}
+		curr = connected
+	}
+	return curr.NetworkSettings.SandboxID, nil
+}
+
 func (daemon *Daemon) getNetworkStats(c *container.Container) ([]*libcontainer.NetworkInterface, error) {
 	var list []*libcontainer.NetworkInterface
 
-	sb, err := daemon.netController.SandboxByID(c.NetworkSettings.SandboxID)
+	sandboxID, err := daemon.getNetworkSandboxID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := daemon.netController.SandboxByID(sandboxID)
 	if err != nil {
 		return list, err
 	}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -232,3 +232,42 @@ func (s *DockerSuite) TestApiStatsContainerNotFound(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 }
+
+func (s *DockerSuite) TestApiStatsNoStreamConnectedContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	out1, _ := runSleepingContainer(c)
+	id1 := strings.TrimSpace(out1)
+	c.Assert(waitRun(id1), checker.IsNil)
+
+	out2, _ := runSleepingContainer(c, "--net", "container:"+id1)
+	id2 := strings.TrimSpace(out2)
+	c.Assert(waitRun(id2), checker.IsNil)
+
+	ch := make(chan error)
+	go func() {
+		resp, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id2), nil, "")
+		defer body.Close()
+		if err != nil {
+			ch <- err
+		}
+		if resp.StatusCode != http.StatusOK {
+			ch <- fmt.Errorf("Invalid StatusCode %v", resp.StatusCode)
+		}
+		if resp.Header.Get("Content-Type") != "application/json" {
+			ch <- fmt.Errorf("Invalid 'Content-Type' %v", resp.Header.Get("Content-Type"))
+		}
+		var v *types.Stats
+		if err := json.NewDecoder(body).Decode(&v); err != nil {
+			ch <- err
+		}
+		ch <- nil
+	}()
+
+	select {
+	case err := <-ch:
+		c.Assert(err, checker.IsNil, check.Commentf("Error in stats remote API: %v", err))
+	case <-time.After(15 * time.Second):
+		c.Fatalf("Stats did not return after timeout")
+	}
+}


### PR DESCRIPTION
Cherry-picks the fix from upstream https://github.com/docker/docker/commit/faf2b6f7aaca7f9ef400e227921b8125590fc9e5

Fixes https://github.com/coreos/bugs/issues/1526 for 1.10.3.
