### PR TITLE
Backport fix for docker stats in 1.11.2

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1572,8 +1572,27 @@ func (daemon *Daemon) GetContainerStats(container *container.Container) (*types.
 	return stats, nil
 }
 
+// Resolve Network SandboxID in case the container reuse another container's network stack
+func (daemon *Daemon) getNetworkSandboxID(c *container.Container) (string, error) {
+	curr := c
+	for curr.HostConfig.NetworkMode.IsContainer() {
+		containerID := curr.HostConfig.NetworkMode.ConnectedContainer()
+		connected, err := daemon.GetContainer(containerID)
+		if err != nil {
+			return "", fmt.Errorf("Could not get container for %s", containerID)
+		}
+		curr = connected
+	}
+	return curr.NetworkSettings.SandboxID, nil
+}
+
 func (daemon *Daemon) getNetworkStats(c *container.Container) (map[string]types.NetworkStats, error) {
-	sb, err := daemon.netController.SandboxByID(c.NetworkSettings.SandboxID)
+	sandboxID, err := daemon.getNetworkSandboxID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := daemon.netController.SandboxByID(sandboxID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-picks the fix from upstream https://github.com/docker/docker/commit/faf2b6f7aaca7f9ef400e227921b8125590fc9e5

Fixes https://github.com/coreos/bugs/issues/1526 for 1.11.2.
