### PR TITLE
Work around races from systemd-networkd hijacking the veths

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
@@ -826,6 +827,55 @@ func setHairpinMode(link netlink.Link, enable bool) error {
 	return nil
 }
 
+func waitForIfaces(ifaceNames []string, timeout time.Duration, trigger func() error) error {
+	// Map interface names to their readiness states (false by default)
+	ifaceStates := make(map[string]bool)
+	allRunning := func() bool {
+		for _, ifaceState := range ifaceStates {
+			if !ifaceState {
+				return false
+			}
+		}
+		return true
+	}
+	for _, ifaceName := range ifaceNames {
+		ifaceStates[ifaceName] = false
+	}
+
+	// Start watching for link changes
+	notifyLink := make(chan netlink.LinkUpdate)
+	notifyDone := make(chan struct{})
+	netlink.LinkSubscribe(notifyLink, notifyDone)
+	defer close(notifyDone)
+
+	// Run the given function to trigger link changes
+	if err := trigger(); err != nil {
+		return err
+	}
+
+	// Do not return until the given interfaces are running, or timeout
+	timer := time.After(timeout)
+	for {
+		select {
+		case update := <-notifyLink:
+			if update.Header.Type == syscall.RTM_NEWLINK &&
+				update.IfInfomsg.Flags&syscall.IFF_RUNNING != 0 {
+				ifaceName := update.Link.Attrs().Name
+				if _, set := ifaceStates[ifaceName]; set {
+					logrus.Debugf("LinkSubscribe notified %s is running", ifaceName)
+					ifaceStates[ifaceName] = true
+					if allRunning() {
+						return nil
+					}
+				}
+			}
+		case <-timer:
+			logrus.Warnf("timeout after %s waiting for network interfaces %v", timeout, ifaceNames)
+			return nil // Don't return an error since netlink messages are not reliable
+		}
+	}
+}
+
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	defer osl.InitOSContext()()
 
@@ -898,12 +948,18 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		return err
 	}
 
-	// Generate and add the interface pipe host <-> sandbox
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: hostIfName, TxQLen: 0},
-		PeerName:  containerIfName}
-	if err = netlink.LinkAdd(veth); err != nil {
-		return types.InternalErrorf("failed to add the host (%s) <=> sandbox (%s) pair interfaces: %v", hostIfName, containerIfName, err)
+	// Generate and add the interface pipe host <-> sandbox, synchronously
+	err = waitForIfaces([]string{containerIfName, hostIfName}, time.Second, func() error {
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: hostIfName, TxQLen: 0},
+			PeerName:  containerIfName}
+		if err = netlink.LinkAdd(veth); err != nil {
+			return types.InternalErrorf("failed to add the host (%s) <=> sandbox (%s) pair interfaces: %v", hostIfName, containerIfName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Get the host side pipe interface handler


### PR DESCRIPTION
Our networkd configuration matches everything, telling networkd to
manage any interface that ever appears.  When networkd manages an
interface, it wipes all existing configuration on it.  This results
in a race condition, where Docker would set up its interfaces, then
networkd would steal it, remove it from the bridge, etc.

To work around this temporarily, this changes Docker to wait for
networkd to fully bring up the interfaces before applying its own
configuration.
