### PR TITLE
Fix "failed to close stdin" warnings

### DIFF
--- a/libcontainerd/process_linux.go
+++ b/libcontainerd/process_linux.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -81,6 +82,9 @@ func (p *process) sendCloseStdin() error {
 		Pid:        p.friendlyName,
 		CloseStdin: true,
 	})
+	if err != nil && (strings.Contains(err.Error(), "container not found") || strings.Contains(err.Error(), "process not found")) {
+		return nil
+	}
 	return err
 }
 

--- a/runconfig/streams.go
+++ b/runconfig/streams.go
@@ -135,7 +135,7 @@ func (streamConfig *StreamConfig) CopyToPipe(iop libcontainerd.IOPipe) {
 			go func() {
 				pools.Copy(iop.Stdin, stdin)
 				if err := iop.Stdin.Close(); err != nil {
-					logrus.Errorf("failed to close stdin: %+v", err)
+					logrus.Warnf("failed to close stdin: %+v", err)
 				}
 			}()
 		}


### PR DESCRIPTION
This is a backport of docker/docker@f9ddac3f3cb1edece22f4515671cf9b461975a12.