### PR TITLE
Fix GetNameServerAsCIDR

### DIFF
--- a/vendor/github.com/docker/libnetwork/resolvconf/resolvconf.go
+++ b/vendor/github.com/docker/libnetwork/resolvconf/resolvconf.go
@@ -178,7 +178,14 @@ func GetNameservers(resolvConf []byte, kind int) []string {
 func GetNameserversAsCIDR(resolvConf []byte) []string {
 	nameservers := []string{}
 	for _, nameserver := range GetNameservers(resolvConf, types.IP) {
-		nameservers = append(nameservers, nameserver+"/32")
+		var address string
+		// If IPv6, strip zone if present
+		if strings.Contains(nameserver, ":") {
+			address = strings.Split(nameserver, "%")[0] + "/128"
+		} else {
+			address = nameserver + "/32"
+		}
+		nameservers = append(nameservers, address)
 	}
 	return nameservers
 }


### PR DESCRIPTION
Backport of https://github.com/docker/libnetwork/pull/1623, but applied within the vendor'd copy.

Fixes the kola failure for 1.13.