### PR TITLE
graphdriver: prefer overlay over devicemapper

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -56,8 +56,8 @@ var (
 		"aufs",
 		"btrfs",
 		"zfs",
-		"devicemapper",
 		"overlay",
+		"devicemapper",
 		"vfs",
 	}
 


### PR DESCRIPTION
This is a partial backport of https://github.com/moby/moby/pull/27932/commits/299beff1c4e2406d1e96c90a9e86e0770dd4342d

More importantly, this is the behavior we already achieved via the
dockerd helper script.
https://github.com/coreos/coreos-overlay/blob/bafeb2375e4ebc0351023a34e856eecda486592b/app-emulation/docker/files/dockerd#L38-L60

The intent of this change is to remove the need for that helper script
to make this judgement since the docker daemon itself already has the
facilities to do so, and to do so in a slightly more correct manner.

This is part of fixing https://github.com/coreos/bugs/issues/1945 I
suspect.